### PR TITLE
- converted to JUCE module

### DIFF
--- a/code_editor/TextEditor.cpp
+++ b/code_editor/TextEditor.cpp
@@ -136,6 +136,7 @@ void mcl::GutterComponent::paint (Graphics& g)
     if (transform.getTranslationX() < GUTTER_WIDTH)
     {
         auto shadowRect = getLocalBounds().withLeft (GUTTER_WIDTH).withWidth (12);
+
         auto gradient = ColourGradient::horizontal (ln.contrasting().withAlpha (0.3f),
                                                     Colours::transparentBlack, shadowRect);
         g.setFillType (gradient);
@@ -1104,7 +1105,9 @@ mcl::TextEditor::TextEditor()
 
 mcl::TextEditor::~TextEditor()
 {
+#if MCL_ENABLE_OPEN_GL
     context.detach();
+#endif
 }
 
 void mcl::TextEditor::setFont (Font font)
@@ -1260,7 +1263,12 @@ void mcl::TextEditor::mouseDown (const MouseEvent& e)
             case 3: renderScheme = RenderScheme::usingGlyphArrangement; break;
             case 4: document.lines.cacheGlyphArrangement = ! document.lines.cacheGlyphArrangement; break;
             case 5: allowCoreGraphics = ! allowCoreGraphics; break;
+#if MCL_ENABLE_OPEN_GL
             case 6: useOpenGLRendering = ! useOpenGLRendering; if (useOpenGLRendering) context.attachTo (*this); else context.detach(); break;
+#else
+			// You haven't enabled open GL
+			case 6: jassertfalse; break;
+#endif
             case 7: enableSyntaxHighlighting = ! enableSyntaxHighlighting; break;
             case 8: drawProfilingInfo = ! drawProfilingInfo; break;
             case 9: DEBUG_TOKENS = ! DEBUG_TOKENS; break;

--- a/code_editor/TextEditor.hpp
+++ b/code_editor/TextEditor.hpp
@@ -10,11 +10,7 @@
  */
 
 #pragma once
-#define DONT_SET_USING_JUCE_NAMESPACE 1
 #include "JuceHeader.h"
-
-
-
 
 namespace mcl {
     /**
@@ -617,6 +613,9 @@ private:
     juce::Point<float> translation;
     juce::AffineTransform transform;
     juce::UndoManager undo;
+
+#if MCL_ENABLE_OPEN_GL
     juce::OpenGLContext context;
+#endif
 };
 

--- a/mcl_editor.cpp
+++ b/mcl_editor.cpp
@@ -1,0 +1,16 @@
+/** ============================================================================
+ *
+ * mcl_editor JUCE module
+ *
+ * Copyright (C) Jonathan Zrake
+ *
+ * You may use, distribute and modify this code under the terms of the GPL3
+ * license.
+ * =============================================================================
+ */
+
+#include "mcl_editor.h"
+ 
+// I'd suggest to split up this big file to multiple files per class and include them here one by one 
+// They will be compiled as one compilation unit anyway, but it eases navigation
+#include "code_editor/TextEditor.cpp"

--- a/mcl_editor.h
+++ b/mcl_editor.h
@@ -1,0 +1,85 @@
+/** ============================================================================
+ *
+ * mcl_editor JUCE module
+ *
+ * Copyright (C) Jonathan Zrake
+ *
+ * You may use, distribute and modify this code under the terms of the GPL3
+ * license.
+ * =============================================================================
+ */
+
+/******************************************************************************
+
+BEGIN_JUCE_MODULE_DECLARATION
+
+  ID:               mcl_editor
+  vendor:           Jonathan Zrake
+  version:          0.0.1
+  name:             MCL Code Editor
+  description:      modern code editor for JUCE
+  website:          https://github.com/jzrake/MclTextEditor
+  license:          GPL
+
+  dependencies:     juce_core, juce_cryptography, juce_data_structures, juce_events, juce_graphics, juce_gui_basics, juce_gui_extra
+
+END_JUCE_MODULE_DECLARATION
+
+******************************************************************************/
+
+#ifndef MCL_EDITOR_INCLUDED
+#define MCL_EDITOR_INCLUDED
+
+#include "AppConfig.h"
+
+#include <juce_gui_extra/juce_gui_extra.h>
+
+
+
+/** CONFIG: MCL_ENABLE_OPEN_GL
+*
+*	Disable this if your project doesn't include the open gl module
+*/
+#ifndef MCL_ENABLE_OPEN_GL
+#define MCL_ENABLE_OPEN_GL 1
+#endif
+
+/** Config: TEST_MULTI_CARET_EDITING
+*
+*	Enable this to test the multi caret editing
+*/
+#ifndef TEST_MULTI_CARET_EDITING
+#define TEST_MULTI_CARET_EDITING 1
+#endif
+
+/** Config: TEST_SYNTAX_SUPPORT
+*
+*	Enable this to test the syntax highlighting
+*/
+#ifndef TEST_SYNTAX_SUPPORT
+#define TEST_SYNTAX_SUPPORT 1
+#endif
+
+
+/** Config: ENABLE_CARET_BLINK
+*
+*	Enable this to make the caret blink (disabled by default)
+*/
+#ifndef ENABLE_CARET_BLINK
+#define ENABLE_CARET_BLINK 1
+#endif
+
+/** Config: PROFILE_PAINTS
+*
+*	Enable this to show profile statistics for the paint routine performance.
+*/
+#ifndef PROFILE_PAINTS
+#define PROFILE_PAINTS 0
+#endif
+
+
+// I'd suggest to split up this big file to multiple files per class and include them here one by one
+#include "code_editor/TextEditor.hpp"
+
+
+#endif   // MCL_EDITOR_INCLUDED

--- a/mcl_editor.mm
+++ b/mcl_editor.mm
@@ -1,0 +1,1 @@
+#include "mcl_editor.cpp"


### PR DESCRIPTION
This is the code as JUCE module. I have made the following changes:

- moved the file into subdirectory (a JUCE module only has a few files in the root directory).
- removed the DONT_USE_JUCE_NAMESPACE macro. JUCE modules normally use it and it messes up compilation
- moved all macros from the TextEditor.cpp file to the configuration file
- added MCL_ENABLE_OPEN_GL flag to enable compilation for projects that don't include the juce_open_gl module

What I didn't do was to split the TextEditor.hpp / cpp file into multiple smaller files (but you can do that and include all files in the original order in the module.h / module.cpp file)

